### PR TITLE
Add global price multipliers for all singlebuilt items

### DIFF
--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -25,8 +25,28 @@
 AutoBlackMarketPriceMult=0.5
 
 ; TODO: make this MCM toggled
-; This is the global cost multiplier for every single-built item
-GlobalCostMult=2.0f
+; These are the global cost multipliers for every single-built item
+
+; Rookie
++ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=0)
++ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=0)
++ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=0)
+ArtifactCostMultiplier[0]=2.0
+; Veteran
++ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=1)
++ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=1)
++ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=1)
+ArtifactCostMultiplier[1]=2.0
+; Commander
++ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=2)
++ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=2)
++ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=2)
+ArtifactCostMultiplier[2]=2.0
+; Legend
++ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=3)
++ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=3)
++ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=3)
+ArtifactCostMultiplier[3]=2.0
 
 ; TODO: make this MCM toggled
 ; Toggle for each type of prototype item. If turned off, the corresponding TLP items will not show up in your campaign
@@ -172,59 +192,6 @@ PrototypeArmorsets=true
 +arrPrototypesToDisable="TLE_Pistol"
 +arrPrototypesToDisable="TLE_Sword"
 
-; Change the cost of hardcoded vanilla items
-
-+arrItemCostOverrides=(ItemName="Medikit", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="Medikit", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-+arrItemCostOverrides=(ItemName="NanoMedikit", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="NanoMedikit", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-
-+arrItemCostOverrides=(ItemName="FlashbangGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=13)))
-+arrItemCostOverrides=(ItemName="FlashbangGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20)))
-
-+arrItemCostOverrides=(ItemName="SmokeGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10)))
-+arrItemCostOverrides=(ItemName="SmokeGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="SmokeGrenadeMk2", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10)))
-+arrItemCostOverrides=(ItemName="SmokeGrenadeMk2", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-
-+arrItemCostOverrides=(ItemName="NanofiberVest", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=8), ResourceCosts[1]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1)))
-+arrItemCostOverrides=(ItemName="NanofiberVest", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2)))
-
-+arrItemCostOverrides=(ItemName="Hellweave", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="CorpseChryssalid", Quantity=1)))
-+arrItemCostOverrides=(ItemName="Hellweave", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="CorpseChryssalid", Quantity=2)))
-
-+arrItemCostOverrides=(ItemName="BattleScanner", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12)))
-+arrItemCostOverrides=(ItemName="BattleScanner", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-
-+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ResourceCosts[1]=(ItemTemplateName="CorpseFaceless", Quantity=1)))
-+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="CorpseFaceless", Quantity=2)))
-
-+arrItemCostOverrides=(ItemName="MindShield", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="CorpseSectoid", Quantity=1)))
-+arrItemCostOverrides=(ItemName="MindShield", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="CorpseSectoid", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="CombatStims", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="CorpseBerserker", Quantity=1)))
-+arrItemCostOverrides=(ItemName="CombatStims", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="CorpseBerserker", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="BluescreenRounds", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
-+arrItemCostOverrides=(ItemName="BluescreenRounds", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=100)))
-
-+arrItemCostOverrides=(ItemName="EMPGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-+arrItemCostOverrides=(ItemName="EMPGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
-+arrItemCostOverrides=(ItemName="EMPGrenadeMk2", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-+arrItemCostOverrides=(ItemName="EMPGrenadeMk2", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
-
-+arrItemCostOverrides=(ItemName="ProximityMine", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=40)))
-+arrItemCostOverrides=(ItemName="ProximityMine", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=70)))
-
-+arrItemCostOverrides=(ItemName="SustainingSphere", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="CorpseAdventPriest", Quantity=1)))
-+arrItemCostOverrides=(ItemName="SustainingSphere", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="CorpseAdventPriest", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="RefractionField", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="CorpseSpectre", Quantity=1)))
-+arrItemCostOverrides=(ItemName="RefractionField", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="CorpseSpectre", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="UltrasonicLure", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="UltrasonicLure", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30)))
-
 ; Vanilla Armors-------------------------
 [MediumPlatedArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PlatedArmor", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
@@ -297,3 +264,59 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts
 
 [PoweredTemplarArmor_Diff_3 X2ArmorTemplate]
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=65), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=7))
+
+; TODO: make this MCM toggled
+; Turn this option to true to change the cost of hardcoded vanilla items according to the arrItemCostOverrides defined below
+; The overridden prices generally make items cheaper for campaigns where you will need a lot of each item. Not recommended for a standard campaign.
+EnableUtilityItemOverrides=false
+
++arrItemCostOverrides=(ItemName="Medikit", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
++arrItemCostOverrides=(ItemName="Medikit", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
++arrItemCostOverrides=(ItemName="NanoMedikit", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
++arrItemCostOverrides=(ItemName="NanoMedikit", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
+
++arrItemCostOverrides=(ItemName="FlashbangGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=13)))
++arrItemCostOverrides=(ItemName="FlashbangGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20)))
+
++arrItemCostOverrides=(ItemName="SmokeGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10)))
++arrItemCostOverrides=(ItemName="SmokeGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
++arrItemCostOverrides=(ItemName="SmokeGrenadeMk2", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10)))
++arrItemCostOverrides=(ItemName="SmokeGrenadeMk2", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
+
++arrItemCostOverrides=(ItemName="NanofiberVest", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=8), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1)))
++arrItemCostOverrides=(ItemName="NanofiberVest", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2)))
+
++arrItemCostOverrides=(ItemName="Hellweave", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ArtifactCosts[0]=(ItemTemplateName="CorpseChryssalid", Quantity=1)))
++arrItemCostOverrides=(ItemName="Hellweave", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ArtifactCosts[0]=(ItemTemplateName="CorpseChryssalid", Quantity=2)))
+
++arrItemCostOverrides=(ItemName="BattleScanner", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12)))
++arrItemCostOverrides=(ItemName="BattleScanner", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
+
++arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=1)))
++arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=2)))
+
++arrItemCostOverrides=(ItemName="MindShield", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1)))
++arrItemCostOverrides=(ItemName="MindShield", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1)))
+
++arrItemCostOverrides=(ItemName="CombatStims", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseBerserker", Quantity=1)))
++arrItemCostOverrides=(ItemName="CombatStims", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseBerserker", Quantity=1)))
+
++arrItemCostOverrides=(ItemName="BluescreenRounds", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
++arrItemCostOverrides=(ItemName="BluescreenRounds", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=100)))
+
++arrItemCostOverrides=(ItemName="EMPGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
++arrItemCostOverrides=(ItemName="EMPGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
++arrItemCostOverrides=(ItemName="EMPGrenadeMk2", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
++arrItemCostOverrides=(ItemName="EMPGrenadeMk2", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
+
++arrItemCostOverrides=(ItemName="ProximityMine", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=40)))
++arrItemCostOverrides=(ItemName="ProximityMine", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=70)))
+
++arrItemCostOverrides=(ItemName="SustainingSphere", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventPriest", Quantity=1)))
++arrItemCostOverrides=(ItemName="SustainingSphere", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventPriest", Quantity=1)))
+
++arrItemCostOverrides=(ItemName="RefractionField", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseSpectre", Quantity=1)))
++arrItemCostOverrides=(ItemName="RefractionField", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ArtifactCosts[0]=(ItemTemplateName="CorpseSpectre", Quantity=1)))
+
++arrItemCostOverrides=(ItemName="UltrasonicLure", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
++arrItemCostOverrides=(ItemName="UltrasonicLure", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30)))

--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -24,6 +24,16 @@
 
 AutoBlackMarketPriceMult=0.5
 
+; TODO: make this MCM toggled
+; This is the global cost multiplier for every single-built item
+GlobalCostMult=2.0f
+
+; TODO: make this MCM toggled
+; Toggle for each type of prototype item. If turned off, the corresponding TLP items will not show up in your campaign
+PrototypePrimaries=true
+PrototypeSecondaries=true
+PrototypeArmorsets=true
+
 ; Make Single Build-------------------------
 +arrMakeItemBuildable=(ItemName="AssaultRifle_MG")
 +arrMakeItemBuildable=(ItemName="AssaultRifle_BM")
@@ -161,11 +171,6 @@ AutoBlackMarketPriceMult=0.5
 +arrPrototypesToDisable="TLE_Cannon"
 +arrPrototypesToDisable="TLE_Pistol"
 +arrPrototypesToDisable="TLE_Sword"
-
-; Toggle for each type of prototype item. If turned off, the corresponding TLP items will not show up in your campaign
-PrototypePrimaries=true
-PrototypeSecondaries=true
-PrototypeArmorsets=true
 
 ; Change the cost of hardcoded vanilla items
 

--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -35,24 +35,23 @@ AutoBlackMarketPriceMult=0.5
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=0)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=0)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=0)
-+ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=0)
++ArtifactCostScalars=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=0)
 ; Veteran
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=1)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=1)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=1)
-+ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=1)
++ArtifactCostScalars=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=1)
 ; Commander
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=2)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=2)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=2)
-+ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=2)
++ArtifactCostScalars=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=2)
 ; Legend
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=3)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=3)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=3)
-+ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=3)
++ArtifactCostScalars=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=3)
 
-; TODO: make this MCM toggled
 ; Toggle for each type of prototype item. If turned off, the corresponding TLP items will not show up in your campaign
 PrototypePrimaries=true
 PrototypeSecondaries=true

--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -24,29 +24,33 @@
 
 AutoBlackMarketPriceMult=0.5
 
-; These are the global cost multipliers for every single-build item
+; These are the global cost multipliers for every individually-built item
 ; Artifacts are stuff like corpses or elerium cores
+
+; This means that any price, defined anywhere, for any item in arrMakeItemBuildable will be multiplied by 2
+; With Covert Infiltration installed, the global multiplier is set to 1
+; Therefore, balance your item prices with respect to Covert Infiltration, and they will be auto-adjusted for vanilla
 
 ; Rookie
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=0)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=0)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=0)
-ArtifactCostMultiplier[0]=2.0
++ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=0)
 ; Veteran
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=1)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=1)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=1)
-ArtifactCostMultiplier[1]=2.0
++ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=1)
 ; Commander
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=2)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=2)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=2)
-ArtifactCostMultiplier[2]=2.0
++ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=2)
 ; Legend
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=3)
 +ResourceCostScalars=(ItemTemplateName="AlienAlloy", Scalar=2.0, Difficulty=3)
 +ResourceCostScalars=(ItemTemplateName="EleriumDust", Scalar=2.0, Difficulty=3)
-ArtifactCostMultiplier[3]=2.0
++ArtifactCostMultiplier=(ItemTemplateName="AllArtifacts", Scalar=2.0, Difficulty=3)
 
 ; TODO: make this MCM toggled
 ; Toggle for each type of prototype item. If turned off, the corresponding TLP items will not show up in your campaign
@@ -192,6 +196,15 @@ PrototypeArmorsets=true
 +arrPrototypesToDisable="TLE_Pistol"
 +arrPrototypesToDisable="TLE_Sword"
 
+; Most basegame utility items are hardcoded and cannot normally have their costs changed via config
+; With PA you can change item prices according to the arrItemCostOverrides defined below
+; These prices will override anything set under the item's own config header
+; Item Cost Overrides are NOT subject to the global price multiplier
+
+; for example, here's an override to make the meme bacon cheaper
+;+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=1)))
+;+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=2)))
+
 ; Vanilla Armors-------------------------
 [MediumPlatedArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PlatedArmor", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
@@ -264,59 +277,3 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts
 
 [PoweredTemplarArmor_Diff_3 X2ArmorTemplate]
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=65), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=7))
-
-; TODO: make this MCM toggled
-; Turn this option to true to change the cost of hardcoded vanilla items according to the arrItemCostOverrides defined below
-; The overridden prices generally make items cheaper for campaigns where you will need a lot of each item. Not recommended for a vanilla campaign.
-EnableUtilityItemOverrides=false
-
-+arrItemCostOverrides=(ItemName="Medikit", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="Medikit", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-+arrItemCostOverrides=(ItemName="NanoMedikit", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="NanoMedikit", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-
-+arrItemCostOverrides=(ItemName="FlashbangGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=13)))
-+arrItemCostOverrides=(ItemName="FlashbangGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20)))
-
-+arrItemCostOverrides=(ItemName="SmokeGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10)))
-+arrItemCostOverrides=(ItemName="SmokeGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="SmokeGrenadeMk2", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10)))
-+arrItemCostOverrides=(ItemName="SmokeGrenadeMk2", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-
-+arrItemCostOverrides=(ItemName="NanofiberVest", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=8), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1)))
-+arrItemCostOverrides=(ItemName="NanofiberVest", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2)))
-
-+arrItemCostOverrides=(ItemName="Hellweave", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ArtifactCosts[0]=(ItemTemplateName="CorpseChryssalid", Quantity=1)))
-+arrItemCostOverrides=(ItemName="Hellweave", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ArtifactCosts[0]=(ItemTemplateName="CorpseChryssalid", Quantity=2)))
-
-+arrItemCostOverrides=(ItemName="BattleScanner", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12)))
-+arrItemCostOverrides=(ItemName="BattleScanner", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-
-+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=1)))
-+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=2)))
-
-+arrItemCostOverrides=(ItemName="MindShield", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1)))
-+arrItemCostOverrides=(ItemName="MindShield", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="CombatStims", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseBerserker", Quantity=1)))
-+arrItemCostOverrides=(ItemName="CombatStims", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseBerserker", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="BluescreenRounds", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
-+arrItemCostOverrides=(ItemName="BluescreenRounds", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=100)))
-
-+arrItemCostOverrides=(ItemName="EMPGrenade", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-+arrItemCostOverrides=(ItemName="EMPGrenade", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
-+arrItemCostOverrides=(ItemName="EMPGrenadeMk2", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25)))
-+arrItemCostOverrides=(ItemName="EMPGrenadeMk2", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50)))
-
-+arrItemCostOverrides=(ItemName="ProximityMine", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=40)))
-+arrItemCostOverrides=(ItemName="ProximityMine", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=70)))
-
-+arrItemCostOverrides=(ItemName="SustainingSphere", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventPriest", Quantity=1)))
-+arrItemCostOverrides=(ItemName="SustainingSphere", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventPriest", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="RefractionField", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ArtifactCosts[0]=(ItemTemplateName="CorpseSpectre", Quantity=1)))
-+arrItemCostOverrides=(ItemName="RefractionField", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ArtifactCosts[0]=(ItemTemplateName="CorpseSpectre", Quantity=1)))
-
-+arrItemCostOverrides=(ItemName="UltrasonicLure", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))
-+arrItemCostOverrides=(ItemName="UltrasonicLure", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30)))

--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -27,8 +27,8 @@ AutoBlackMarketPriceMult=0.5
 ; These are the global cost multipliers for every individually-built item
 ; Artifacts are stuff like corpses or elerium cores
 
-; This means that any price, defined anywhere, for any item in arrMakeItemBuildable will be multiplied by 2
-; With Covert Infiltration installed, the global multiplier is set to 1
+; This means that any price, defined anywhere, for any item in arrMakeItemBuildable or arrAutoConvertItem will be multiplied by 2
+; With Covert Infiltration installed, the global multiplier is set to 1.0, and the below configs will be ignored
 ; Therefore, balance your item prices with respect to Covert Infiltration, and they will be auto-adjusted for vanilla
 
 ; Rookie

--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -24,8 +24,8 @@
 
 AutoBlackMarketPriceMult=0.5
 
-; TODO: make this MCM toggled
-; These are the global cost multipliers for every single-built item
+; These are the global cost multipliers for every single-build item
+; Artifacts are stuff like corpses or elerium cores
 
 ; Rookie
 +ResourceCostScalars=(ItemTemplateName="Supplies", Scalar=2.0, Difficulty=0)
@@ -267,7 +267,7 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=65), ResourceCosts
 
 ; TODO: make this MCM toggled
 ; Turn this option to true to change the cost of hardcoded vanilla items according to the arrItemCostOverrides defined below
-; The overridden prices generally make items cheaper for campaigns where you will need a lot of each item. Not recommended for a standard campaign.
+; The overridden prices generally make items cheaper for campaigns where you will need a lot of each item. Not recommended for a vanilla campaign.
 EnableUtilityItemOverrides=false
 
 +arrItemCostOverrides=(ItemName="Medikit", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15)))

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PAHelpers.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PAHelpers.uc
@@ -5,19 +5,15 @@ static function bool IsDLCLoaded (coerce string DLCName)
     local XComOnlineEventMgr EventManager;
     local int                Index;
 	
-	`PA_Trace("Checking Mod: " $ DLCName);
+	`PA_Trace("Checking if loaded: " $ DLCName);
 
 	if (DLCName == "")
 		return true;
 
     EventManager = `ONLINEEVENTMGR;
 	
-	`PA_Trace("Installed Mods: " $ EventManager.GetNumDLC());
-
     for (Index = 0; Index < EventManager.GetNumDLC(); Index++)    
     {
-		`PA_Trace("--> " $ EventManager.GetDLCNames(Index));
-
         if(EventManager.GetDLCNames(Index) == name(DLCName))    
         {
             return true;

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PAHelpers.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PAHelpers.uc
@@ -1,20 +1,20 @@
 class PAHelpers extends Object abstract;
 
-static function bool IsDLCLoaded (coerce string DLCName)
+static function bool IsDLCLoaded (name DLCName)
 {
     local XComOnlineEventMgr EventManager;
     local int                Index;
 	
 	`PA_Trace("Checking if loaded: " $ DLCName);
 
-	if (DLCName == "")
+	if (DLCName == '')
 		return true;
 
     EventManager = `ONLINEEVENTMGR;
 	
     for (Index = 0; Index < EventManager.GetNumDLC(); Index++)    
     {
-        if(EventManager.GetDLCNames(Index) == name(DLCName))    
+        if(EventManager.GetDLCNames(Index) == DLCName)    
         {
             return true;
         }

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PAHelpers.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PAHelpers.uc
@@ -2,14 +2,29 @@ class PAHelpers extends Object abstract;
 
 static function bool IsDLCLoaded (coerce string DLCName)
 {
-	local array<string> DLCs;
+    local XComOnlineEventMgr EventManager;
+    local int                Index;
+	
+	`PA_Trace("Checking Mod: " $ DLCName);
 
 	if (DLCName == "")
 		return true;
 
-	DLCs = class'Helpers'.static.GetInstalledDLCNames();
+    EventManager = `ONLINEEVENTMGR;
+	
+	`PA_Trace("Installed Mods: " $ EventManager.GetNumDLC());
 
-	return DLCs.Find(DLCName) != INDEX_NONE;
+    for (Index = 0; Index < EventManager.GetNumDLC(); Index++)    
+    {
+		`PA_Trace("--> " $ EventManager.GetDLCNames(Index));
+
+        if(EventManager.GetDLCNames(Index) == name(DLCName))    
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 ///////////////////

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -6,7 +6,7 @@ var config array<ItemFromDLC> arrKillItems;
 var config array<TradingPostValueModifier> arrTradingPostModifiers;
 
 var config(StrategyTuning) array<StrategyCostScalar> ResourceCostScalars;
-var config(StrategyTuning) float ArtifactCostMultiplier;
+var config(StrategyTuning) array<float> ArtifactCostMultiplier;
 
 var config(StrategyTuning) bool PrototypePrimaries;
 var config(StrategyTuning) bool PrototypeSecondaries;
@@ -56,7 +56,7 @@ static function MakeItemsBuildable ()
 
 	UIEventListener = PAEventListener_UI(class'XComEngine'.static.GetClassDefaultObject(class'PAEventListener_UI'));
 	ItemTemplateManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
-	`PA_Log("Making items buildable");
+	`PA_Log("Making" @ default.arrMakeItemBuildable.Length @ "items buildable");
 
 	foreach default.arrMakeItemBuildable(TemplateItem)
 	{
@@ -76,8 +76,10 @@ static function MakeItemBuildable (name TemplateName, X2ItemTemplateManager Item
 	local X2ItemTemplate ItemTemplate;
 
 	ItemTemplateManager.FindDataTemplateAllDifficulties(TemplateName, DifficultyVariants);
+	
+	`PA_Trace("Evaluating" @ TemplateName);
 
-	foreach DifficultyVariants(DataTemplate)
+	foreach DifficulityVariants(DataTemplate)
 	{
 		ItemTemplate = X2ItemTemplate(DataTemplate);
 
@@ -279,8 +281,7 @@ static function OverrideItemCosts ()
 	local X2DataTemplate DataTemplate;
 	local X2ItemTemplate ItemTemplate;
 	local ItemCostOverride ItemCostOverrideEntry;
-	local StrategyCostScalar CostScalar;
-	local int TemplateDifficulty, i;
+	local int TemplateDifficulty;
 
 	if (!default.EnableUtilityItemOverrides) return;
 	
@@ -349,7 +350,8 @@ static function OverrideItemCosts ()
 
 static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 {
-	local int TemplateDifficulty;
+	local StrategyCostScalar CostScalar;
+	local int TemplateDifficulty, i;
 
 	if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Rookie))
 	{
@@ -370,18 +372,18 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 	else
 	{
 		TemplateDifficulty = -1; // Untranslatable Bitfield
-		`PA_Log("Cannot adjust cost - invalid difficulty");
+		`PA_Trace("Cannot adjust cost - invalid difficulty");
 		return;
 	}
 	
-	`PA_Log("Adjusting item cost of " $ ItemTemplate.DataName $ " on difficulty " $ TemplateDifficulty);
+	`PA_Trace("Adjusting item cost of " $ ItemTemplate.DataName $ " on difficulty " $ TemplateDifficulty);
 	for (i = 0; i < ItemTemplate.Cost.ResourceCosts.Length; i++)
 	{
 		foreach default.ResourceCostScalars(CostScalar)
 		{
 			if (ItemTemplate.Cost.ResourceCosts[i].ItemTemplateName == CostScalar.ItemTemplateName && TemplateDifficulty == CostScalar.Difficulty)
 			{
-				`PA_Log("--> " $ CostScalar.ItemTemplateName $ ": " $ CostScalar.Scalar);
+				`PA_Trace("--> " $ CostScalar.ItemTemplateName $ ": " $ CostScalar.Scalar);
 				ItemTemplate.Cost.ResourceCosts[i].Quantity = Round(ItemTemplate.Cost.ResourceCosts[i].Quantity * CostScalar.Scalar);
 			}
 		}
@@ -389,8 +391,8 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 
 	for (i = 0; i < ItemTemplate.Cost.ArtifactCosts.Length; i++)
 	{
-		`PA_Log("--> " $ ItemTemplate.Cost.ArtifactCosts[i].ItemTemplateName $ ": " $ `ScaleStrategyArrayInt(default.ArtifactCostMultiplier));
-		ItemTemplate.Cost.ArtifactCosts[i].Quantity = ItemTemplate.Cost.ArtifactCosts[i].Quantity * `ScaleStrategyArrayInt(default.ArtifactCostMultiplier);
+		`PA_Trace("--> " $ ItemTemplate.Cost.ArtifactCosts[i].ItemTemplateName $ ": " $ `ScaleStrategyArrayFloat(default.ArtifactCostMultiplier));
+		ItemTemplate.Cost.ArtifactCosts[i].Quantity = ItemTemplate.Cost.ArtifactCosts[i].Quantity * `ScaleStrategyArrayFloat(default.ArtifactCostMultiplier);
 	}
 }
 

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -367,7 +367,7 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 		return;
 	}
 
-	if (class'PAHelpers'.static.IsDLCLoaded("CovertInfiltration"))
+	if (class'PAHelpers'.static.IsDLCLoaded('CovertInfiltration'))
 	{
 		`PA_Trace("Covert Infiltration Detected!");
 		ResourceMultipliers = default.ResourceCostScalars_CI;
@@ -413,7 +413,7 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 
 static function PatchTLPArmorsets ()
 {
-	if (!class'PAHelpers'.static.IsDLCLoaded("TLE"))
+	if (!class'PAHelpers'.static.IsDLCLoaded('TLE'))
 		return;
 
 	PatchTLPRanger();
@@ -499,7 +499,7 @@ static function PatchTLPWeapons ()
 	local X2WeaponTemplate				Template;
 	local name							ItemName;
 	
-	if (!class'PAHelpers'.static.IsDLCLoaded("TLE"))
+	if (!class'PAHelpers'.static.IsDLCLoaded('TLE'))
 		return;
 
 	TemplateManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
@@ -554,7 +554,7 @@ static protected function bool ReturnFalse ()
 
 static function PatchWeaponTechs ()
 {
-	if (!class'PAHelpers'.static.IsDLCLoaded("TLE"))
+	if (!class'PAHelpers'.static.IsDLCLoaded('TLE'))
 		return;
 
 	if(default.PrototypePrimaries)

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -1,10 +1,15 @@
 class PATemplateMods extends Object abstract config(StrategyTuning);
 
 var config array<ItemFromDLC> arrDataSetsToForceVariants;
-
 var config array<ItemFromDLC> arrMakeItemBuildable;
 var config array<ItemFromDLC> arrKillItems;
 var config array<TradingPostValueModifier> arrTradingPostModifiers;
+
+var config(StrategyTuning) float GlobalCostMult;
+
+var config(StrategyTuning) bool PrototypePrimaries;
+var config(StrategyTuning) bool PrototypeSecondaries;
+var config(StrategyTuning) bool PrototypeArmorsets;
 
 var config array<name> arrPrototypesToDisable;
 var config bool PrototypePrimaries;
@@ -102,6 +107,16 @@ static function MakeItemBuildable (name TemplateName, X2ItemTemplateManager Item
 		ItemTemplate.CanBeBuilt = true;
 		ItemTemplate.bInfiniteItem = false;
 		ItemTemplate.CreatorTemplateName = '';
+		
+		for (i = 0; i < ItemTemplate.Cost.ResourceCosts.Length; i++)
+		{
+			ItemTemplate.Cost.ResourceCosts[i].Quantity = ItemTemplate.Cost.ResourceCosts[i].Quantity * default.GlobalCostMult;
+		}
+
+		for (i = 0; i < ItemTemplate.Cost.ArtifactCosts.Length; i++)
+		{
+			ItemTemplate.Cost.ArtifactCosts[i].Quantity = ItemTemplate.Cost.ArtifactCosts[i].Quantity * default.GlobalCostMult;
+		}
 
 		`PA_Trace(ItemTemplate.Name @ "was made single-buildable" @ `showvar(ItemTemplate.Requirements.RequiredTechs.Length));
 	}
@@ -268,7 +283,7 @@ static function OverrideItemCosts ()
 	local X2DataTemplate DataTemplate;
 	local X2ItemTemplate ItemTemplate;
 	local ItemCostOverride ItemCostOverrideEntry;
-	local int TemplateDifficulty;
+	local int TemplateDifficulty, i;
 	
 	ItemTemplateManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
 	`PA_Log("Overriding item costs");
@@ -291,6 +306,17 @@ static function OverrideItemCosts ()
 			ItemTemplate = X2ItemTemplate(DifficultyVariants[0]);
 			`PA_Trace(ItemTemplate.DataName $ " has had its cost overridden to non-legend values");
 			ItemTemplate.Cost = ItemCostOverrideEntry.NewCost;
+			
+			for (i = 0; i < ItemTemplate.Cost.ResourceCosts.Length; i++)
+			{
+				ItemTemplate.Cost.ResourceCosts[i].Quantity = ItemTemplate.Cost.ResourceCosts[i].Quantity * default.GlobalCostMult;
+			}
+
+			for (i = 0; i < ItemTemplate.Cost.ArtifactCosts.Length; i++)
+			{
+				ItemTemplate.Cost.ArtifactCosts[i].Quantity = ItemTemplate.Cost.ArtifactCosts[i].Quantity * default.GlobalCostMult;
+			}
+
 			continue;
 		}
 
@@ -323,6 +349,16 @@ static function OverrideItemCosts ()
 			{
 				`PA_Trace(ItemTemplate.DataName $ " on difficulty " $ TemplateDifficulty $ " has had its cost overridden");
 				ItemTemplate.Cost = ItemCostOverrideEntry.NewCost;
+				
+				for (i = 0; i < ItemTemplate.Cost.ResourceCosts.Length; i++)
+				{
+					ItemTemplate.Cost.ResourceCosts[i].Quantity = ItemTemplate.Cost.ResourceCosts[i].Quantity * default.GlobalCostMult;
+				}
+
+				for (i = 0; i < ItemTemplate.Cost.ArtifactCosts.Length; i++)
+				{
+					ItemTemplate.Cost.ArtifactCosts[i].Quantity = ItemTemplate.Cost.ArtifactCosts[i].Quantity * default.GlobalCostMult;
+				}
 			}
 		}
 	}

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -363,24 +363,24 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 	else
 	{
 		TemplateDifficulty = -1; // Untranslatable Bitfield
-		`PA_Log("Cannot adjust cost - invalid difficulty");
+		`PA_Trace("Cannot adjust cost - invalid difficulty");
 		return;
 	}
 
 	if (class'PAHelpers'.static.IsDLCLoaded("CovertInfiltration"))
 	{
-		`PA_Log("Covert Infiltration Detected!");
+		`PA_Trace("Covert Infiltration Detected!");
 		ResourceMultipliers = default.ResourceCostScalars_CI;
 		ArtifactMultipliers = default.ArtifactCostScalars_CI;
 	}
 	else
 	{
-		`PA_Log("Covert Infiltration Missing!");
+		`PA_Trace("Covert Infiltration Missing!");
 		ResourceMultipliers = default.ResourceCostScalars;
 		ArtifactMultipliers = default.ArtifactCostScalars;
 	}
 	
-	`PA_Log("Adjusting item cost of " $ ItemTemplate.DataName $ " on difficulty " $ TemplateDifficulty);
+	`PA_Trace("Adjusting item cost of " $ ItemTemplate.DataName $ " on difficulty " $ TemplateDifficulty);
 
 	for (i = 0; i < ItemTemplate.Cost.ResourceCosts.Length; i++)
 	{
@@ -388,7 +388,7 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 		{
 			if (ItemTemplate.Cost.ResourceCosts[i].ItemTemplateName == CostScalar.ItemTemplateName && TemplateDifficulty == CostScalar.Difficulty)
 			{
-				`PA_Log("--> " $ CostScalar.ItemTemplateName $ ": " $ CostScalar.Scalar);
+				`PA_Trace("--> " $ CostScalar.ItemTemplateName $ ": " $ CostScalar.Scalar);
 				ItemTemplate.Cost.ResourceCosts[i].Quantity = Round(ItemTemplate.Cost.ResourceCosts[i].Quantity * CostScalar.Scalar);
 			}
 		}
@@ -400,7 +400,7 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 		{
 			if ((ItemTemplate.Cost.ArtifactCosts[i].ItemTemplateName == CostScalar.ItemTemplateName || CostScalar.ItemTemplateName == 'AllArtifacts') && TemplateDifficulty == CostScalar.Difficulty)
 			{
-				`PA_Log("--> " $ ItemTemplate.Cost.ArtifactCosts[i].ItemTemplateName $ ": " $ CostScalar.Scalar);
+				`PA_Trace("--> " $ ItemTemplate.Cost.ArtifactCosts[i].ItemTemplateName $ ": " $ CostScalar.Scalar);
 				ItemTemplate.Cost.ArtifactCosts[i].Quantity = Round(ItemTemplate.Cost.ArtifactCosts[i].Quantity * CostScalar.Scalar);
 			}
 		}

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PA_DataStructures.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PA_DataStructures.uc
@@ -17,7 +17,7 @@ struct TradingPostValueModifier
 {
 	var name ItemName;
 	var int NewValue;
-	var string DLC;
+	var name DLC;
 };
 
 struct ItemCostOverride
@@ -25,7 +25,7 @@ struct ItemCostOverride
 	var name ItemName;
 	var array<int> Difficulties;
 	var StrategyCost NewCost;
-	var string DLC;
+	var name DLC;
 };
 
 struct AutoItemConversion
@@ -34,11 +34,11 @@ struct AutoItemConversion
 	var int Supplies;
 	var int Alloys;
 	var int Elerium;
-	var string DLC;
+	var name DLC;
 };
 
 struct ItemFromDLC
 {
 	var name ItemName;
-	var string DLC;
+	var name DLC;
 };


### PR DESCRIPTION
Closes #1 
Requires merge of https://github.com/WOTCStrategyOverhaul/CovertInfiltration/pull/524