### PR TITLE
Create a single config array that handles the entire conversion process

### DIFF
--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -3,16 +3,22 @@
 ; To convert an item to PA's singlebuild system you have two options:
 
 ; The long way is to add your item to arrMakeItemBuildable, arrTradingPostModifiers, arrKillItems,
-; and give it costs and requirements under its own config header
+; and give it costs and requirements under its own config header.
+; This method is much more flexible and can handle a wide array of different modded item setups but is more complicated.
 
-; The short way is to add your item to arrAutoConvertItem, which does the following:
+; The simple way is to add your item to arrAutoConvertItem, which handles the most common
+; way by which modded items are setup but will break when used with more exotic setups.
+; If the mod adds items that are given in infinite quantity to the player when they buy a schematic from engineering,
+; then you can use this option. Anything else will likely need specialized handling using the long way outlined above.
+
+; arrAutoConvertItem will do the following:
 ; - enable the direct building of the item from engineering (same as using arrMakeItemBuildable)
 ; - hide the item's schematic from engineering (same as using arrKillItems)
-; - set the item costs to what the arrAutoConvert parameters are set to (same as using the item's config header except you can't set corpses or other items as costs)
-; - set the item's black market price to AutoBlackMarketPriceMult times the item's supplies cost (same as using arrTradingPostModifiers except the price is automatic rather than manual)
-; - copy the schematic's tech requirements over to the item (same as using the item's config header except you can't manually set the tech requirements to whatever you want)
+; - set the item costs to the specified parameters
+; - set the item's black market price to AutoBlackMarketPriceMult times the item's supplies cost
+; - copy the schematic's tech requirements over to the item
 
-+arrAutoConvertItem=(ItemName="TestItem", Supplies=10, Alloys=5, Elerium=5)
+;+arrAutoConvertItem=(ItemName="TestItem", Supplies=10, Alloys=5, Elerium=5)
 
 AutoBlackMarketPriceMult=0.5
 

--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -1,5 +1,21 @@
 [PrototypeArmoury.PATemplateMods]
 
+; To convert an item to PA's singlebuild system you have two options:
+
+; The long way is to add your item to arrMakeItemBuildable, arrTradingPostModifiers, arrKillItems,
+; and give it costs and requirements under its own config header
+
+; The short way is to add your item to arrAutoConvertItem, which does the following:
+; - enable the direct building of the item from engineering (same as using arrMakeItemBuildable)
+; - hide the item's schematic from engineering (same as using arrKillItems)
+; - set the item costs to what the arrAutoConvert parameters are set to (same as using the item's config header except you can't set corpses or other items as costs)
+; - set the item's black market price to AutoBlackMarketPriceMult times the item's supplies cost (same as using arrTradingPostModifiers except the price is automatic rather than manual)
+; - copy the schematic's tech requirements over to the item (same as using the item's config header except you can't manually set the tech requirements to whatever you want)
+
++arrAutoConvertItem=(ItemName="TestItem", Supplies=10, Alloys=5, Elerium=5)
+
+AutoBlackMarketPriceMult=0.5
+
 ; Make Single Build-------------------------
 +arrMakeItemBuildable="AssaultRifle_MG"
 +arrMakeItemBuildable="AssaultRifle_BM"
@@ -85,16 +101,8 @@
 +arrTradingPostModifiers=(ItemName="PoweredSkirmisherArmor", NewValue=15)
 +arrTradingPostModifiers=(ItemName="PlatedTemplarArmor", NewValue=7)
 +arrTradingPostModifiers=(ItemName="PoweredTemplarArmor", NewValue=15)
-+arrTradingPostModifiers=(ItemName="RangerPlatedArmor", NewValue=6)
-+arrTradingPostModifiers=(ItemName="RangerPoweredArmor", NewValue=12)
-+arrTradingPostModifiers=(ItemName="SpecialistPlatedArmor", NewValue=6)
-+arrTradingPostModifiers=(ItemName="SpecialistPoweredArmor", NewValue=12)
-+arrTradingPostModifiers=(ItemName="GrenadierPlatedArmor", NewValue=6)
-+arrTradingPostModifiers=(ItemName="GrenadierPoweredArmor", NewValue=12)
-+arrTradingPostModifiers=(ItemName="SharpshooterPlatedArmor", NewValue=6)
-+arrTradingPostModifiers=(ItemName="SharpshooterPoweredArmor", NewValue=12)
-+arrTradingPostModifiers=(ItemName="PsiOperativePlatedArmor", NewValue=6)
-+arrTradingPostModifiers=(ItemName="PsiOperativePoweredArmor", NewValue=12)
++arrTradingPostModifiers=(ItemName="TLE_PlatedArmor", NewValue=6)
++arrTradingPostModifiers=(ItemName="TLE_PoweredArmor", NewValue=12)
 
 ; Remove Schematics-------------------------
 +arrKillItems="AssaultRifle_MG_Schematic"

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -1,30 +1,20 @@
-class PATemplateMods extends Object abstract config(PrototypeArmoury);
+class PATemplateMods extends Object abstract config(StrategyTuning);
 
-struct TradingPostValueModifier
-{
-	var name ItemName;
-	var int NewValue;
-};
+var config array<name> arrDataSetsToForceVariants;
 
-struct ItemCostOverride
-{
-	var name ItemName;
-	var array<int> Difficulties;
-	var StrategyCost NewCost;
-};
+var config array<name> arrMakeItemBuildable;
+var config array<name> arrKillItems;
+var config array<TradingPostValueModifier> arrTradingPostModifiers;
 
-var config(StrategyTuning) array<name> arrDataSetsToForceVariants;
+var config array<name> arrPrototypesToDisable;
+var config bool PrototypePrimaries;
+var config bool PrototypeSecondaries;
+var config bool PrototypeArmorsets;
 
-var config(StrategyTuning) array<name> arrMakeItemBuildable;
-var config(StrategyTuning) array<name> arrKillItems;
-var config(StrategyTuning) array<TradingPostValueModifier> arrTradingPostModifiers;
+var config array<ItemCostOverride> arrItemCostOverrides;
 
-var config(StrategyTuning) array<name> arrPrototypesToDisable;
-var config(StrategyTuning) bool PrototypePrimaries;
-var config(StrategyTuning) bool PrototypeSecondaries;
-var config(StrategyTuning) bool PrototypeArmorsets;
-
-var config(StrategyTuning) array<ItemCostOverride> arrItemCostOverrides;
+var config array<AutoItemConversion> arrAutoConvertItem;
+var config float AutoBlackMarketPriceMult;
 
 static function ForceDifficultyVariants ()
 {
@@ -48,13 +38,8 @@ static function ForceDifficultyVariants ()
 
 static function MakeItemsBuildable ()
 {
-	local ItemAvaliableImageReplacement ImageReplacement;
 	local X2ItemTemplateManager ItemTemplateManager;
-	local array<X2DataTemplate> DifficulityVariants;
 	local PAEventListener_UI UIEventListener;
-	local X2WeaponTemplate WeaponTemplate;
-	local X2DataTemplate DataTemplate;
-	local X2ItemTemplate ItemTemplate;
 	local name TemplateName;
 	
 	UIEventListener = PAEventListener_UI(class'XComEngine'.static.GetClassDefaultObject(class'PAEventListener_UI'));
@@ -63,71 +48,83 @@ static function MakeItemsBuildable ()
 
 	foreach default.arrMakeItemBuildable(TemplateName)
 	{
-		DifficulityVariants.Length = 0;
-		ItemTemplateManager.FindDataTemplateAllDifficulties(TemplateName, DifficulityVariants);
+		MakeItemBuildable(TemplateName, ItemTemplateManager, UIEventListener);
+	}
+}
 
-		foreach DifficulityVariants(DataTemplate)
+static function MakeItemBuildable (name TemplateName, X2ItemTemplateManager ItemTemplateManager, PAEventListener_UI UIEventListener)
+{
+	local ItemAvaliableImageReplacement ImageReplacement;
+	local array<X2DataTemplate> DifficultyVariants;
+	local X2WeaponTemplate WeaponTemplate;
+	local X2DataTemplate DataTemplate;
+	local X2ItemTemplate ItemTemplate;
+
+	ItemTemplateManager.FindDataTemplateAllDifficulties(TemplateName, DifficultyVariants);
+
+	foreach DifficultyVariants(DataTemplate)
+	{
+		ItemTemplate = X2ItemTemplate(DataTemplate);
+
+		if (ItemTemplate == none)
 		{
-			ItemTemplate = X2ItemTemplate(DataTemplate);
-
-			if (ItemTemplate == none)
-			{
-				`PA_WarnNoStack(DataTemplate.Name @ "is not an X2ItemTemplate");
-				continue;
-			}
-
-			// Check if we need to replace the image on "ItemAvaliable" screen
-			// Do this before we nuke the schematic ref
-			WeaponTemplate = X2WeaponTemplate(ItemTemplate);
-			if (
-				// If this item/weapon has attachments
-				WeaponTemplate != none && WeaponTemplate.DefaultAttachments.Length > 0
-
-				// And it has a creator schematic (although it should, otherwise why is it in this code at all?)
-				&& ItemTemplate.CreatorTemplateName != ''
-
-				// And we haven't added the replacement already (due to difficulty variants)
-				&& UIEventListener.ItemAvaliableImageReplacementsAutomatic.Find('TargetItem', ItemTemplate.DataName) == INDEX_NONE
-			)
-			{
-				ImageReplacement.TargetItem = ItemTemplate.DataName;
-				ImageReplacement.ImageSourceItem = ItemTemplate.CreatorTemplateName;
-
-				UIEventListener.ItemAvaliableImageReplacementsAutomatic.AddItem(ImageReplacement);
-				`PA_Trace("Added image replacement for" @ ItemTemplate.DataName);
-			}
-
-			ItemTemplate.CanBeBuilt = true;
-			ItemTemplate.bInfiniteItem = false;
-			ItemTemplate.CreatorTemplateName = '';
-
-			`PA_Trace(ItemTemplate.Name @ "was made single-buildable" @ `showvar(ItemTemplate.Requirements.RequiredTechs.Length));
+			`PA_WarnNoStack(DataTemplate.Name @ "is not an X2ItemTemplate");
+			continue;
 		}
+
+		// Check if we need to replace the image on "ItemAvaliable" screen
+		// Do this before we nuke the schematic ref
+		WeaponTemplate = X2WeaponTemplate(ItemTemplate);
+		if (
+			// If this item/weapon has attachments
+			WeaponTemplate != none && WeaponTemplate.DefaultAttachments.Length > 0
+
+			// And it has a creator schematic (although it should, otherwise why is it in this code at all?)
+			&& ItemTemplate.CreatorTemplateName != ''
+
+			// And we haven't added the replacement already (due to difficulty variants)
+			&& UIEventListener.ItemAvaliableImageReplacementsAutomatic.Find('TargetItem', ItemTemplate.DataName) == INDEX_NONE
+		)
+		{
+			ImageReplacement.TargetItem = ItemTemplate.DataName;
+			ImageReplacement.ImageSourceItem = ItemTemplate.CreatorTemplateName;
+
+			UIEventListener.ItemAvaliableImageReplacementsAutomatic.AddItem(ImageReplacement);
+			`PA_Trace("Added image replacement for" @ ItemTemplate.DataName);
+		}
+
+		ItemTemplate.CanBeBuilt = true;
+		ItemTemplate.bInfiniteItem = false;
+		ItemTemplate.CreatorTemplateName = '';
+
+		`PA_Trace(ItemTemplate.Name @ "was made single-buildable" @ `showvar(ItemTemplate.Requirements.RequiredTechs.Length));
 	}
 }
 
 static function ApplyTradingPostModifiers ()
 {
 	local X2ItemTemplateManager ItemTemplateManager;
-	local X2ItemTemplate ItemTemplate;
 	local TradingPostValueModifier ValueModifier;
 
 	ItemTemplateManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
 
 	foreach default.arrTradingPostModifiers(ValueModifier)
 	{
-		ItemTemplate = ItemTemplateManager.FindItemTemplate(ValueModifier.ItemName);
-
-		ItemTemplate.TradingPostValue = ValueModifier.NewValue;
+		ApplyTradingPostModifier(ValueModifier, ItemTemplateManager);
 	}
+}
+
+static function ApplyTradingPostModifier (TradingPostValueModifier ValueModifier, X2ItemTemplateManager ItemTemplateManager)
+{
+	local X2ItemTemplate ItemTemplate;
+
+	ItemTemplate = ItemTemplateManager.FindItemTemplate(ValueModifier.ItemName);
+	ItemTemplate.TradingPostValue = ValueModifier.NewValue;
 }
 
 static function KillItems ()
 {
 	local X2ItemTemplateManager ItemTemplateManager;
-	local array<X2DataTemplate> DifficulityVariants;
-	local X2DataTemplate DataTemplate;
-	local X2ItemTemplate ItemTemplate;
 	local name TemplateName;
 
 	ItemTemplateManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
@@ -135,37 +132,141 @@ static function KillItems ()
 
 	foreach default.arrKillItems(TemplateName)
 	{
-		DifficulityVariants.Length = 0;
-		ItemTemplateManager.FindDataTemplateAllDifficulties(TemplateName, DifficulityVariants);
+		KillItem(TemplateName, ItemTemplateManager);
+	}
+}
 
-		foreach DifficulityVariants(DataTemplate)
+static function KillItem (name TemplateName, X2ItemTemplateManager ItemTemplateManager)
+{
+	local array<X2DataTemplate> DifficultyVariants;
+	local X2DataTemplate DataTemplate;
+	local X2ItemTemplate ItemTemplate;
+
+	ItemTemplateManager.FindDataTemplateAllDifficulties(TemplateName, DifficultyVariants);
+
+	foreach DifficultyVariants(DataTemplate)
+	{
+		ItemTemplate = X2ItemTemplate(DataTemplate);
+
+		if (ItemTemplate == none)
 		{
-			ItemTemplate = X2ItemTemplate(DataTemplate);
-
-			if (ItemTemplate == none)
-			{
-				`PA_WarnNoStack(DataTemplate.Name @ "is not an X2ItemTemplate");
-				continue;
-			}
-
-			// "Killing" inspired by LW2
-			ItemTemplate.CanBeBuilt = false;
-			ItemTemplate.PointsToComplete = 999999;
-			ItemTemplate.Requirements.RequiredEngineeringScore = 999999;
-			ItemTemplate.Requirements.bVisibleifPersonnelGatesNotMet = false;
-			ItemTemplate.OnBuiltFn = none;
-			ItemTemplate.Cost.ResourceCosts.Length = 0;
-			ItemTemplate.Cost.ArtifactCosts.Length = 0;
-
-			`PA_Trace(ItemTemplate.Name @ "was killed");
+			`PA_WarnNoStack(DataTemplate.Name @ "is not an X2ItemTemplate");
+			continue;
 		}
+
+		// "Killing" inspired by LW2
+		ItemTemplate.CanBeBuilt = false;
+		ItemTemplate.PointsToComplete = 999999;
+		ItemTemplate.Requirements.RequiredEngineeringScore = 999999;
+		ItemTemplate.Requirements.bVisibleifPersonnelGatesNotMet = false;
+		ItemTemplate.OnBuiltFn = none;
+		ItemTemplate.Cost.ResourceCosts.Length = 0;
+		ItemTemplate.Cost.ArtifactCosts.Length = 0;
+
+		`PA_Trace(ItemTemplate.Name @ "was killed");
+	}
+}
+
+static function AutoConvertItems ()
+{
+	local X2ItemTemplateManager ItemTemplateManager;
+	local PAEventListener_UI UIEventListener;
+	local AutoItemConversion ConversionEntry;
+	local X2ItemTemplate ItemTemplate;
+	local name TemplateName;
+	local ArtifactCost Cost;
+	
+	ItemTemplateManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
+	UIEventListener = PAEventListener_UI(class'XComEngine'.static.GetClassDefaultObject(class'PAEventListener_UI'));
+
+	foreach default.arrAutoConvertItem(ConversionEntry)
+	{
+		TemplateName = ConversionEntry.ItemName;
+		ItemTemplate = ItemTemplateManager.FindItemTemplate(TemplateName);
+		
+		`PA_Log("Autoconverting: " $ TemplateName);
+
+		if (ItemTemplate == none)
+		{
+			`PA_WarnNoStack(TemplateName @ "is not an X2ItemTemplate");
+			continue;
+		}
+
+		CopyItemRequirements(TemplateName, ItemTemplateManager);
+		KillItemSchematic(TemplateName, ItemTemplateManager);
+		MakeItemBuildable(TemplateName, ItemTemplateManager, UIEventListener);
+
+		ItemTemplate.TradingPostValue = int(default.AutoBlackMarketPriceMult * ConversionEntry.Supplies);
+
+		ItemTemplate.Cost.ResourceCosts.Length = 0;
+		ItemTemplate.Cost.ArtifactCosts.Length = 0;
+		
+		if (ConversionEntry.Supplies > 0)
+		{
+			Cost.ItemTemplateName = 'Supplies';
+			Cost.Quantity = ConversionEntry.Supplies;
+			ItemTemplate.Cost.ResourceCosts.AddItem(Cost);
+		}
+		
+		if (ConversionEntry.Alloys > 0)
+		{
+			Cost.ItemTemplateName = 'AlienAlloy';
+			Cost.Quantity = ConversionEntry.Alloys;
+			ItemTemplate.Cost.ResourceCosts.AddItem(Cost);
+		}
+		
+		if (ConversionEntry.Elerium > 0)
+		{
+			Cost.ItemTemplateName = 'EleriumDust';
+			Cost.Quantity = ConversionEntry.Elerium;
+			ItemTemplate.Cost.ResourceCosts.AddItem(Cost);
+		}
+	}
+}
+
+static function KillItemSchematic (name TemplateName, X2ItemTemplateManager ItemTemplateManager)
+{
+	local X2ItemTemplate ItemTemplate;
+
+	ItemTemplate = ItemTemplateManager.FindItemTemplate(TemplateName);
+
+	if (ItemTemplate == none)
+	{
+		`PA_WarnNoStack(TemplateName @ "is not an X2ItemTemplate");
+		return;
+	}
+
+	KillItem(ItemTemplate.CreatorTemplateName, ItemTemplateManager);
+}
+
+static function CopyItemRequirements (name TemplateName, X2ItemTemplateManager ItemTemplateManager)
+{
+	local array<X2DataTemplate> DifficultyVariants;
+	local X2DataTemplate DataTemplate;
+	local X2ItemTemplate ItemTemplate, SchematicTemplate;
+	
+	ItemTemplateManager.FindDataTemplateAllDifficulties(TemplateName, DifficultyVariants);
+
+	foreach DifficultyVariants(DataTemplate)
+	{
+		ItemTemplate = X2ItemTemplate(DataTemplate);
+
+		if (ItemTemplate == none)
+		{
+			`PA_WarnNoStack(DataTemplate.Name @ "is not an X2ItemTemplate");
+			continue;
+		}
+
+		SchematicTemplate = ItemTemplateManager.FindItemTemplate(ItemTemplate.CreatorTemplateName);
+
+		ItemTemplate.Requirements = SchematicTemplate.Requirements;
 	}
 }
 
 static function OverrideItemCosts ()
 {
 	local X2ItemTemplateManager ItemTemplateManager;
-	local array<X2DataTemplate> DifficulityVariants;
+	local array<X2DataTemplate> DifficultyVariants;
 	local X2DataTemplate DataTemplate;
 	local X2ItemTemplate ItemTemplate;
 	local ItemCostOverride ItemCostOverrideEntry;
@@ -176,23 +277,23 @@ static function OverrideItemCosts ()
 
 	foreach default.arrItemCostOverrides(ItemCostOverrideEntry)
 	{
-		DifficulityVariants.Length = 0;
-		ItemTemplateManager.FindDataTemplateAllDifficulties(ItemCostOverrideEntry.ItemName, DifficulityVariants);
+		DifficultyVariants.Length = 0;
+		ItemTemplateManager.FindDataTemplateAllDifficulties(ItemCostOverrideEntry.ItemName, DifficultyVariants);
 		
-		if (DifficulityVariants.Length == 0)
+		if (DifficultyVariants.Length == 0)
 		{
 			`PA_WarnNoStack(ItemCostOverrideEntry.ItemName @ "is not an X2ItemTemplate, cannot override cost");
 			continue;
 		}
-		else if (DifficulityVariants.Length == 1 && ItemCostOverrideEntry.Difficulties.Find(3) > -1)
+		else if (DifficultyVariants.Length == 1 && ItemCostOverrideEntry.Difficulties.Find(3) > -1)
 		{
-			ItemTemplate = X2ItemTemplate(DifficulityVariants[0]);
+			ItemTemplate = X2ItemTemplate(DifficultyVariants[0]);
 			`PA_Trace(ItemTemplate.DataName $ " has had its cost overridden to non-legend values");
 			ItemTemplate.Cost = ItemCostOverrideEntry.NewCost;
 			continue;
 		}
 
-		foreach DifficulityVariants(DataTemplate)
+		foreach DifficultyVariants(DataTemplate)
 		{
 			ItemTemplate = X2ItemTemplate(DataTemplate);
 
@@ -339,14 +440,14 @@ static function PatchTLPWeapons ()
 static function DisableLockAndLoadBreakthrough ()
 {
 	local X2StrategyElementTemplateManager Manager;
-	local array<X2DataTemplate> DifficulityVariants;
+	local array<X2DataTemplate> DifficultyVariants;
 	local X2DataTemplate DataTemplate;
 	local X2TechTemplate TechTemplate;
 
 	Manager = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
-	Manager.FindDataTemplateAllDifficulties('BreakthroughReuseWeaponUpgrades', DifficulityVariants);
+	Manager.FindDataTemplateAllDifficulties('BreakthroughReuseWeaponUpgrades', DifficultyVariants);
 	
-	foreach DifficulityVariants(DataTemplate)
+	foreach DifficultyVariants(DataTemplate)
 	{
 		TechTemplate = X2TechTemplate(DataTemplate);
 
@@ -397,14 +498,14 @@ static function PatchWeaponTechs ()
 static protected function AddPrototypeItem (name TechName, name Prototype)
 {
 	local X2StrategyElementTemplateManager Manager;
-	local array<X2DataTemplate> DifficulityVariants;
+	local array<X2DataTemplate> DifficultyVariants;
 	local X2DataTemplate DataTemplate;
 	local X2TechTemplate TechTemplate;
 
 	Manager = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
-	Manager.FindDataTemplateAllDifficulties(TechName, DifficulityVariants);
+	Manager.FindDataTemplateAllDifficulties(TechName, DifficultyVariants);
 	
-	foreach DifficulityVariants(DataTemplate)
+	foreach DifficultyVariants(DataTemplate)
 	{
 		TechTemplate = X2TechTemplate(DataTemplate);
 

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -192,8 +192,8 @@ static function AutoConvertItems ()
 			continue;
 		}
 
-		CopyItemRequirements(TemplateName, ItemTemplateManager);
-		KillItemSchematic(TemplateName, ItemTemplateManager);
+		CopyItemRequirements(ItemTemplate, ItemTemplateManager);
+		KillItem(ItemTemplate.CreatorTemplateName, ItemTemplateManager);
 		MakeItemBuildable(TemplateName, ItemTemplateManager, UIEventListener);
 
 		ItemTemplate.TradingPostValue = int(default.AutoBlackMarketPriceMult * ConversionEntry.Supplies);
@@ -224,40 +224,23 @@ static function AutoConvertItems ()
 	}
 }
 
-static function KillItemSchematic (name TemplateName, X2ItemTemplateManager ItemTemplateManager)
-{
-	local X2ItemTemplate ItemTemplate;
-
-	ItemTemplate = ItemTemplateManager.FindItemTemplate(TemplateName);
-
-	if (ItemTemplate == none)
-	{
-		`PA_WarnNoStack(TemplateName @ "is not an X2ItemTemplate");
-		return;
-	}
-
-	KillItem(ItemTemplate.CreatorTemplateName, ItemTemplateManager);
-}
-
-static function CopyItemRequirements (name TemplateName, X2ItemTemplateManager ItemTemplateManager)
+static function CopyItemRequirements (X2ItemTemplate ItemTemplate, X2ItemTemplateManager ItemTemplateManager)
 {
 	local array<X2DataTemplate> DifficultyVariants;
 	local X2DataTemplate DataTemplate;
-	local X2ItemTemplate ItemTemplate, SchematicTemplate;
+	local X2ItemTemplate SchematicTemplate;
 	
-	ItemTemplateManager.FindDataTemplateAllDifficulties(TemplateName, DifficultyVariants);
+	ItemTemplateManager.FindDataTemplateAllDifficulties(ItemTemplate.CreatorTemplateName, DifficultyVariants);
 
 	foreach DifficultyVariants(DataTemplate)
 	{
-		ItemTemplate = X2ItemTemplate(DataTemplate);
+		SchematicTemplate = X2ItemTemplate(DataTemplate);
 
-		if (ItemTemplate == none)
+		if (SchematicTemplate == none)
 		{
 			`PA_WarnNoStack(DataTemplate.Name @ "is not an X2ItemTemplate");
 			continue;
 		}
-
-		SchematicTemplate = ItemTemplateManager.FindItemTemplate(ItemTemplate.CreatorTemplateName);
 
 		ItemTemplate.Requirements = SchematicTemplate.Requirements;
 	}

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PA_DataStructures.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PA_DataStructures.uc
@@ -12,3 +12,25 @@ struct ItemAvaliableImageReplacement
 	// Pull image from template
 	var name ImageSourceItem;
 };
+
+struct TradingPostValueModifier
+{
+	var name ItemName;
+	var int NewValue;
+};
+
+struct ItemCostOverride
+{
+	var name ItemName;
+	var array<int> Difficulties;
+	var StrategyCost NewCost;
+};
+
+struct AutoItemConversion
+{
+	var name ItemName;
+	var int Supplies;
+	var int Alloys;
+	var int Elerium;
+};
+

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2DownloadableContentInfo_PrototypeArmoury.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2DownloadableContentInfo_PrototypeArmoury.uc
@@ -23,6 +23,8 @@ static event OnPostTemplatesCreated ()
 	class'PATemplateMods'.static.MakeItemsBuildable();
 	class'PATemplateMods'.static.ApplyTradingPostModifiers();
 	class'PATemplateMods'.static.KillItems();
+	
+	class'PATemplateMods'.static.AutoConvertItems();
 	class'PATemplateMods'.static.OverrideItemCosts();
 
 	class'PATemplateMods'.static.PatchTLPArmorsets();


### PR DESCRIPTION
Closes #9 

I made a new array in StrategyTuning that basically does everything that arrMakeItemBuildable, arrTradingPostModifiers, and arrKillItems do, and more. For most modded items, since most of them use the schematic system, all you need to do is grab the dataname and put in your desired prices, like so:
```
+arrAutoConvertItem=(ItemName="TestItem", Supplies=10, Alloys=5, Elerium=5)
```