### PR TITLE
Give TLP prototype armours sidegraded stats

### DIFF
--- a/PrototypeArmoury/Config/Items/XComGameCore.ini
+++ b/PrototypeArmoury/Config/Items/XComGameCore.ini
@@ -1,0 +1,16 @@
+[PrototypeArmoury.X2DownloadableContentInfo_PrototypeArmoury]
++ArmorUtilitySlotsMods=(ArmorTemplate="TLE_KevlarArmor", Mod=-1)
+; With the T2 and T3, we can simply mark that they don't have an extra utility slot, but for the T1 we need to use this method to revoke the base utility slot
+
+[PrototypeArmoury.X2Ability_PA_TLEArmorAbilitySet]
+; +2 health over medium kevlar
+TLE_KEVLAR_HEALTH_BONUS = 2
+TLE_KEVLAR_MITIGATION_AMOUNT = 0
+
+; +1 armour over medium plated
+TLE_PLATED_HEALTH_BONUS = 4
+TLE_PLATED_MITIGATION_AMOUNT = 1
+
+; +1 armour over medium powered
+TLE_POWERED_HEALTH_BONUS = 6
+TLE_POWERED_MITIGATION_AMOUNT = 2

--- a/PrototypeArmoury/PrototypeArmoury.x2proj
+++ b/PrototypeArmoury/PrototypeArmoury.x2proj
@@ -27,6 +27,9 @@
     <Content Include="Config\Items\XComContent.ini">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Config\Items\XComGameCore.ini">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Config\Items\XComStrategyTuning.ini">
       <SubType>Content</SubType>
     </Content>
@@ -133,6 +136,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\PrototypeArmoury\Classes\UIUtilities_PA.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\PrototypeArmoury\Classes\X2Ability_PA_TLEArmorAbilitySet.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\PrototypeArmoury\Classes\X2DownloadableContentInfo_PrototypeArmoury.uc" />

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2Ability_PA_TLEArmorAbilitySet.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2Ability_PA_TLEArmorAbilitySet.uc
@@ -1,0 +1,128 @@
+//---------------------------------------------------------------------------------------
+//  AUTHOR:  ArcaneData
+//  PURPOSE: Creates abilities for infiltration armors.
+//---------------------------------------------------------------------------------------
+//  WOTCStrategyOverhaul Team
+//---------------------------------------------------------------------------------------
+
+class X2Ability_PA_TLEArmorAbilitySet extends X2Ability_ItemGrantedAbilitySet config(GameCore);
+
+var config int TLE_KEVLAR_HEALTH_BONUS;
+var config int TLE_KEVLAR_MITIGATION_AMOUNT;
+
+var config int TLE_PLATED_HEALTH_BONUS;
+var config int TLE_PLATED_MITIGATION_AMOUNT;
+
+var config int TLE_POWERED_HEALTH_BONUS;
+var config int TLE_POWERED_MITIGATION_AMOUNT;
+
+static function array<X2DataTemplate> CreateTemplates()
+{
+	local array<X2DataTemplate> Templates;
+
+	Templates.AddItem(TLE_KevlarArmorStats());
+	Templates.AddItem(TLE_PlatedArmorStats());
+	Templates.AddItem(TLE_PoweredArmorStats());
+
+	return Templates;
+}
+
+static function X2AbilityTemplate TLE_KevlarArmorStats()
+{
+	local X2AbilityTemplate                 Template;	
+	local X2AbilityTrigger					Trigger;
+	local X2AbilityTarget_Self				TargetStyle;
+	local X2Effect_PersistentStatChange		PersistentStatChangeEffect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'TLE_KevlarArmorStats');
+
+	Template.AbilitySourceName = 'eAbilitySource_Item';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.bDisplayInUITacticalText = false;
+
+	Template.AbilityToHitCalc = default.DeadEye;
+
+	TargetStyle = new class'X2AbilityTarget_Self';
+	Template.AbilityTargetStyle = TargetStyle;
+
+	Trigger = new class'X2AbilityTrigger_UnitPostBeginPlay';
+	Template.AbilityTriggers.AddItem(Trigger);
+
+	PersistentStatChangeEffect = new class'X2Effect_PersistentStatChange';
+	PersistentStatChangeEffect.BuildPersistentEffect(1, true, false, false);
+	PersistentStatChangeEffect.AddPersistentStatChange(eStat_HP, default.TLE_KEVLAR_HEALTH_BONUS);
+	PersistentStatChangeEffect.AddPersistentStatChange(eStat_ArmorMitigation, default.TLE_KEVLAR_MITIGATION_AMOUNT);
+
+	Template.AddTargetEffect(PersistentStatChangeEffect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+
+	return Template;	
+}
+
+static function X2AbilityTemplate TLE_PlatedArmorStats()
+{
+	local X2AbilityTemplate                 Template;	
+	local X2AbilityTrigger					Trigger;
+	local X2AbilityTarget_Self				TargetStyle;
+	local X2Effect_PersistentStatChange		PersistentStatChangeEffect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'TLE_PlatedArmorStats');
+
+	Template.AbilitySourceName = 'eAbilitySource_Item';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.bDisplayInUITacticalText = false;
+
+	Template.AbilityToHitCalc = default.DeadEye;
+
+	TargetStyle = new class'X2AbilityTarget_Self';
+	Template.AbilityTargetStyle = TargetStyle;
+
+	Trigger = new class'X2AbilityTrigger_UnitPostBeginPlay';
+	Template.AbilityTriggers.AddItem(Trigger);
+
+	PersistentStatChangeEffect = new class'X2Effect_PersistentStatChange';
+	PersistentStatChangeEffect.BuildPersistentEffect(1, true, false, false);
+	PersistentStatChangeEffect.AddPersistentStatChange(eStat_HP, default.TLE_PLATED_HEALTH_BONUS);
+	PersistentStatChangeEffect.AddPersistentStatChange(eStat_ArmorMitigation, default.TLE_PLATED_MITIGATION_AMOUNT);
+	Template.AddTargetEffect(PersistentStatChangeEffect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+
+	return Template;	
+}
+
+static function X2AbilityTemplate TLE_PoweredArmorStats()
+{
+	local X2AbilityTemplate                 Template;
+	local X2AbilityTrigger					Trigger;
+	local X2AbilityTarget_Self				TargetStyle;
+	local X2Effect_PersistentStatChange		PersistentStatChangeEffect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'TLE_PoweredArmorStats');
+
+	Template.AbilitySourceName = 'eAbilitySource_Item';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.bDisplayInUITacticalText = false;
+
+	Template.AbilityToHitCalc = default.DeadEye;
+
+	TargetStyle = new class'X2AbilityTarget_Self';
+	Template.AbilityTargetStyle = TargetStyle;
+
+	Trigger = new class'X2AbilityTrigger_UnitPostBeginPlay';
+	Template.AbilityTriggers.AddItem(Trigger);
+
+	PersistentStatChangeEffect = new class'X2Effect_PersistentStatChange';
+	PersistentStatChangeEffect.BuildPersistentEffect(1, true, false, false);
+	PersistentStatChangeEffect.AddPersistentStatChange(eStat_HP, default.TLE_POWERED_HEALTH_BONUS);
+	PersistentStatChangeEffect.AddPersistentStatChange(eStat_ArmorMitigation, default.TLE_POWERED_MITIGATION_AMOUNT);
+	Template.AddTargetEffect(PersistentStatChangeEffect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+
+	return Template;
+}

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2DownloadableContentInfo_PrototypeArmoury.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2DownloadableContentInfo_PrototypeArmoury.uc
@@ -2,6 +2,14 @@ class X2DownloadableContentInfo_PrototypeArmoury extends X2DownloadableContentIn
 
 `include(PrototypeArmoury\Src\ModConfigMenuAPI\MCM_API_CfgHelpers.uci)
 
+struct ArmorUtilitySlotsModifier
+{
+	var name ArmorTemplate;
+	var int Mod;
+};
+
+var config(GameCore) array<ArmorUtilitySlotsModifier> ArmorUtilitySlotsMods;
+
 var config(Engine) bool SuppressTraceLogs;
 
 /////////////////
@@ -109,4 +117,23 @@ exec function EnableTrace_PrototypeArmoury (optional bool Enabled = true)
 static function X2DownloadableContentInfo_PrototypeArmoury GetCDO ()
 {
 	return X2DownloadableContentInfo_PrototypeArmoury(class'XComEngine'.static.GetClassDefaultObjectByName(default.Class.Name));
+}
+
+//////////////////////
+/// DLC (HL) HOOKS ///
+//////////////////////
+
+static function GetNumUtilitySlotsOverride (out int NumUtilitySlots, XComGameState_Item EquippedArmor, XComGameState_Unit UnitState, XComGameState CheckGameState)
+{
+	local int i;
+
+	if (EquippedArmor != none)
+	{
+		i = default.ArmorUtilitySlotsMods.Find('ArmorTemplate', EquippedArmor.GetMyTemplateName());
+
+		if (i != INDEX_NONE)
+		{
+			NumUtilitySlots += default.ArmorUtilitySlotsMods[i].Mod;
+		}
+	}
 }

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2Item_PA_TLEArmors.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/X2Item_PA_TLEArmors.uc
@@ -20,13 +20,15 @@ static protected function X2DataTemplate CreateTLPKevlar ()
 	Template.StartingItem = true;
 	Template.CanBeBuilt = false;
 	Template.bInfiniteItem = false;
+	Template.Abilities.AddItem('TLE_KevlarArmorStats');
 	Template.ArmorTechCat = 'conventional';
 	Template.ArmorClass = 'basic';
 	Template.Tier = 0;
 	Template.AkAudioSoldierArmorSwitch = 'Conventional';
 	Template.EquipSound = "StrategyUI_Armor_Equip_Conventional";
-
-	Template.SetUIStatMarkup(class'XLocalizedData'.default.HealthLabel, eStat_HP, 0, true);
+	
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.HealthLabel, eStat_HP, class'X2Ability_PA_TLEArmorAbilitySet'.default.TLE_KEVLAR_HEALTH_BONUS, true);
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.ArmorLabel, eStat_ArmorMitigation, class'X2Ability_PA_TLEArmorAbilitySet'.default.TLE_KEVLAR_MITIGATION_AMOUNT);
 
 	Template.ArmorCat = 'soldier';
 
@@ -40,13 +42,12 @@ static protected function X2DataTemplate CreateTLPPlated ()
 	`CREATE_X2TEMPLATE(class'X2ArmorTemplate', Template, 'TLE_PlatedArmor');
 	Template.strImage = "img:///UILibrary_TLE_Common.TLE_Inv_PLT_Support";
 	Template.ItemCat = 'armor';
-	Template.bAddsUtilitySlot = true;
 	Template.StartingItem = false;
 	Template.CanBeBuilt = false;
 	Template.bInfiniteItem = false;
 	Template.TradingPostValue = 20;
 	Template.PointsToComplete = 0;
-	Template.Abilities.AddItem('MediumPlatedArmorStats');
+	Template.Abilities.AddItem('TLE_PlatedArmorStats');
 	Template.ArmorTechCat = 'plated';
 	Template.ArmorClass = 'medium';
 	Template.Tier = 1;
@@ -54,10 +55,8 @@ static protected function X2DataTemplate CreateTLPPlated ()
 	Template.EquipNarrative = "X2NarrativeMoments.Strategy.CIN_ArmorIntro_PlatedMedium";
 	Template.EquipSound = "StrategyUI_Armor_Equip_Plated";
 
-	//Template.CreatorTemplateName = 'MediumPlatedArmor_Schematic'; // The schematic which creates this item
-	//Template.BaseItem = 'TLE_KevlarArmor'; // Which item this will be upgraded from
-
-	Template.SetUIStatMarkup(class'XLocalizedData'.default.HealthLabel, eStat_HP, class'X2Ability_ItemGrantedAbilitySet'.default.MEDIUM_PLATED_HEALTH_BONUS, true);
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.HealthLabel, eStat_HP, class'X2Ability_PA_TLEArmorAbilitySet'.default.TLE_PLATED_HEALTH_BONUS, true);
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.ArmorLabel, eStat_ArmorMitigation, class'X2Ability_PA_TLEArmorAbilitySet'.default.TLE_PLATED_MITIGATION_AMOUNT);
 
 	Template.ArmorCat = 'soldier';
 
@@ -71,13 +70,12 @@ static protected function X2DataTemplate CreateTLPPowered ()
 	`CREATE_X2TEMPLATE(class'X2ArmorTemplate', Template, 'TLE_PoweredArmor');
 	Template.strImage = "img:///UILibrary_TLE_Common.TLE_Inv_PWR_Support";
 	Template.ItemCat = 'armor';
-	Template.bAddsUtilitySlot = true;
 	Template.StartingItem = false;
 	Template.CanBeBuilt = false;
 	Template.bInfiniteItem = false;
 	Template.TradingPostValue = 60;
 	Template.PointsToComplete = 0;
-	Template.Abilities.AddItem('MediumPoweredArmorStats');
+	Template.Abilities.AddItem('TLE_PoweredArmorStats');
 	Template.ArmorTechCat = 'powered';
 	Template.ArmorClass = 'medium';
 	Template.Tier = 3;
@@ -85,11 +83,8 @@ static protected function X2DataTemplate CreateTLPPowered ()
 	Template.EquipNarrative = "X2NarrativeMoments.Strategy.CIN_ArmorIntro_PoweredMedium";
 	Template.EquipSound = "StrategyUI_Armor_Equip_Powered";
 
-	//Template.CreatorTemplateName = MediumPoweredArmor_Schematic'; // The schematic which creates this item
-	//Template.BaseItem = 'TLE_PlatedArmor'; // Which item this will be upgraded from
-
-	Template.SetUIStatMarkup(class'XLocalizedData'.default.HealthLabel, eStat_HP, class'X2Ability_ItemGrantedAbilitySet'.default.MEDIUM_POWERED_HEALTH_BONUS, true);
-	Template.SetUIStatMarkup(class'XLocalizedData'.default.ArmorLabel, eStat_ArmorMitigation, class'X2Ability_ItemGrantedAbilitySet'.default.MEDIUM_POWERED_MITIGATION_AMOUNT);
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.HealthLabel, eStat_HP, class'X2Ability_PA_TLEArmorAbilitySet'.default.TLE_POWERED_HEALTH_BONUS, true);
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.ArmorLabel, eStat_ArmorMitigation, class'X2Ability_PA_TLEArmorAbilitySet'.default.TLE_POWERED_MITIGATION_AMOUNT);
 
 	Template.ArmorCat = 'soldier';
 


### PR DESCRIPTION
+2 health for kevlar, +1 armor for plated and powered. All have -1 utility slot.
Closes #6 