### PR TITLE
Rebalance inconsistent item resource costs

### DIFF
--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -210,14 +210,14 @@ Requirements=(RequiredTechs[0]="PlatedArmor", RequiredEngineeringScore=10, bVisi
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
 
 [MediumPlatedArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=24), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2))
 
 [MediumPoweredArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PoweredArmor", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
 
 [MediumPoweredArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=7), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=4))
 
 ; Day90 Armors-------------------------
 [PlatedSparkArmor X2SparkArmorTemplate_DLC_3]
@@ -225,14 +225,14 @@ Requirements=(RequiredTechs[0]="PlatedArmor", RequiredSoldierClass="Spark", Requ
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventMEC", Quantity=1))
 
 [PlatedSparkArmor_Diff_3 X2SparkArmorTemplate_DLC_3]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventMEC", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventMEC", Quantity=2))
 
 [PoweredSparkArmor X2SparkArmorTemplate_DLC_3]
 Requirements=(RequiredTechs[0]="PoweredArmor", RequiredSoldierClass="Spark", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=32), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [PoweredSparkArmor_Diff_3 X2SparkArmorTemplate_DLC_3]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=65), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=7))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=64), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 ; WOTC Armors-------------------------
 [PlatedReaperArmor X2ArmorTemplate]
@@ -240,39 +240,39 @@ Requirements=(RequiredTechs[0]="PlatedArmor", RequiredSoldierClass="Reaper", Req
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
 
 [PlatedReaperArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=7), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2))
 
 [PoweredReaperArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PoweredArmor", RequiredSoldierClass="Reaper", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=33), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [PoweredReaperArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=65), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=7))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=66), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 [PlatedSkirmisherArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PlatedArmor", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
 
 [PlatedSkirmisherArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=7), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2))
 
 [PoweredSkirmisherArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PoweredArmor", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=33), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [PoweredSkirmisherArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=65), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=7))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=66), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 [PlatedTemplarArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PlatedArmor", RequiredSoldierClass="Templar", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
 
 [PlatedTemplarArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=7), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2))
 
 [PoweredTemplarArmor X2ArmorTemplate]
 Requirements=(RequiredTechs[0]="PoweredArmor", RequiredSoldierClass="Templar", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=33), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [PoweredTemplarArmor_Diff_3 X2ArmorTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=65), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=7))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=66), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))

--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -257,7 +257,7 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseAdventTrooper", Quantity=2))
 
 [PoweredSkirmisherArmor X2ArmorTemplate]
-Requirements=(RequiredTechs[0]="PoweredArmor", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
+Requirements=(RequiredTechs[0]="PoweredArmor", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=33), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [PoweredSkirmisherArmor_Diff_3 X2ArmorTemplate]

--- a/PrototypeArmoury/Config/Items/XComWeaponTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComWeaponTuning.ini
@@ -21,7 +21,7 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=13), ResourceCosts
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=26), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [Shotgun_BM X2WeaponTemplate]
-Requirements=(RequiredTechs[0]="AlloyCannon", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
+Requirements=(RequiredTechs[0]="AlloyCannon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [Shotgun_BM_Diff_3 X2WeaponTemplate]
@@ -136,7 +136,7 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10), ResourceCosts
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [Sword_BM X2WeaponTemplate]
-Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
+Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=24), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [Sword_BM_Diff_3 X2WeaponTemplate]
@@ -172,10 +172,10 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=32), ResourceCosts
 
 [PsiAmp_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyGatekeeper", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
 
 [PsiAmp_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=38), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=12), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=56), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=12), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
 
 ; Day90 Secondary-------------------------
 [SparkBit_MG X2GremlinTemplate]
@@ -194,14 +194,14 @@ Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=36), ResourceCosts
 
 ; WOTC Secondaries-------------------------
 [WristBlade_MG X2PairedWeaponTemplate]
-Requirements=(RequiredTechs[0]="AutopsyAdventStunLancer", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
+Requirements=(RequiredTechs[0]="AutopsyAdventStunLancer", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=14), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [WristBlade_MG_Diff_3 X2PairedWeaponTemplate]
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [WristBlade_BM X2PairedWeaponTemplate]
-Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
+Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
 
 [WristBlade_BM_Diff_3 X2PairedWeaponTemplate]

--- a/PrototypeArmoury/Config/Items/XComWeaponTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComWeaponTuning.ini
@@ -4,219 +4,219 @@ Requirements=(RequiredTechs[0]="MagnetizedWeapons", RequiredEngineeringScore=10,
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
 
 [AssaultRifle_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=33), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=36), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6))
 
 [AssaultRifle_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="PlasmaRifle", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=43), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=44), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [AssaultRifle_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=87), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=12))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=88), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 [Shotgun_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="MagnetizedWeapons", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=13), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [Shotgun_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=26), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [Shotgun_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AlloyCannon", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [Shotgun_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=37), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 [Cannon_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="GaussWeapons", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
 
 [Cannon_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=31), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6))
 
 [Cannon_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="HeavyPlasma", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=37), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=40), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [Cannon_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=81), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=11), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=7))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=80), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 [SniperRifle_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="GaussWeapons", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
 
 [SniperRifle_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6))
 
 [SniperRifle_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="PlasmaSniper", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=4))
 
 [SniperRifle_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=93), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=9), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=12))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=100), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=8))
 
 ; Day90 Primary-------------------------
 [SparkRifle_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="GaussWeapons", RequiredSoldierClass="Spark", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [SparkRifle_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=55), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8))
 
 [SparkRifle_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="HeavyPlasma", RequiredSoldierClass="Spark", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=45), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=45), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
 
 [SparkRifle_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=80), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=12), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=8))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=90), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=12), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=10))
 
 ; WOTC Primaries-------------------------
 [VektorRifle_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="GaussWeapons", RequiredSoldierClass="Reaper", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=22), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
 
 [VektorRifle_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=44), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6))
 
 [VektorRifle_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="PlasmaSniper", RequiredSoldierClass="Reaper", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=55), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=4))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=55), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=4))
 
 [VektorRifle_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=115), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=10))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=110), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=8))
 
 [Bullpup_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="MagnetizedWeapons", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=22), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [Bullpup_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=40), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8))
 
 [Bullpup_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="PlasmaRifle", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=45), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=45), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=4))
 
 [Bullpup_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=105), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=12), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=8))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=90), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=8))
 
 [ShardGauntlet_MG X2PairedWeaponTemplate]
 Requirements=(RequiredTechs[0]="PlatedArmor", RequiredSoldierClass="Templar", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
 
 [ShardGauntlet_MG_Diff_3 X2PairedWeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6))
 
 [ShardGauntlet_BM X2PairedWeaponTemplate]
 Requirements=(RequiredTechs[0]="PoweredArmor", RequiredSoldierClass="Templar", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 [ShardGauntlet_BM_Diff_3 X2PairedWeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=93), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=15))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=70), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=12))
 
 ; Vanilla Secondaries-------------------------
 [Pistol_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="MagnetizedWeapons", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=8), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1))
 
 [Pistol_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=16), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [Pistol_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="PlasmaRifle", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
 
 [Pistol_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=24), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
 
 [Sword_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyAdventStunLancer", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [Sword_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [Sword_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=23), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=24), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [Sword_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=33), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=48), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 [Gremlin_MG X2GremlinTemplate]
 Requirements=(RequiredTechs[0]="AutopsyAdventMEC", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=8), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1))
 
 [Gremlin_MG_Diff_3 X2GremlinTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=11), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=16), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [Gremlin_BM X2GremlinTemplate]
 Requirements=(RequiredTechs[0]="AutopsySectopod", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=14), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
 
 [Gremlin_BM_Diff_3 X2GremlinTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=4))
 
 [GrenadeLauncher_MG X2GrenadeLauncherTemplate]
 Requirements=(RequiredTechs[0]="AutopsyMuton", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
 
 [GrenadeLauncher_MG_Diff_3 X2GrenadeLauncherTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=43), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=10))
 
 [PsiAmp_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="Psionics", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=17), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=16), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1))
 
 [PsiAmp_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=31), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=32), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseSectoid", Quantity=1))
 
 [PsiAmp_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyGatekeeper", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
 
 [PsiAmp_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=38), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=11), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=38), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=12), ArtifactCosts[0]=(ItemTemplateName="CorpseGateKeeper", Quantity=1))
 
 ; Day90 Secondary-------------------------
 [SparkBit_MG X2GremlinTemplate]
 Requirements=(RequiredTechs[0]="AutopsyAdventMEC", RequiredSoldierClass="Spark", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=9), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=10), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [SparkBit_MG_Diff_3 X2GremlinTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4)
 
 [SparkBit_BM X2GremlinTemplate]
 Requirements=(RequiredTechs[0]="AutopsySectopod", RequiredSoldierClass="Spark", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=14), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [SparkBit_BM_Diff_3 X2GremlinTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=36), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=6))
 
 ; WOTC Secondaries-------------------------
 [WristBlade_MG X2PairedWeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyAdventStunLancer", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=15), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=14), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [WristBlade_MG_Diff_3 X2PairedWeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=23), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4))
 
 [WristBlade_BM X2PairedWeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredSoldierClass="Skirmisher", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
 
 [WristBlade_BM_Diff_3 X2PairedWeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=45), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=8), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=6), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=4))
 
 [Sidearm_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="MagnetizedWeapons", RequiredSoldierClass="Templar", RequiredEngineeringScore=15, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1))
 
 [Sidearm_MG_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=17), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=24), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2))
 
 [Sidearm_BM X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="PlasmaRifle", RequiredSoldierClass="Templar", RequiredEngineeringScore=25, bVisibleIfPersonnelGatesNotMet=true)
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
 
 [Sidearm_BM_Diff_3 X2WeaponTemplate]
-Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=56), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=4), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))


### PR DESCRIPTION
Legend difficulty costs should now be exactly twice that of their non-Legend counterparts, and overall the costs should make more sense. Anyone who has feedback, please let me know in the comments below.

Closes #16 