### PR TITLE
Apply config cost scalars to templates affected by ItemCostOverride

### DIFF
--- a/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
+++ b/PrototypeArmoury/Config/Items/XComStrategyTuning.ini
@@ -203,11 +203,15 @@ RESEARCH_GRANTS_ARMORSET=true
 ; Most basegame utility items are hardcoded and cannot normally have their costs changed via config
 ; With PA you can change item prices according to the arrItemCostOverrides defined below
 ; These prices will override anything set under the item's own config header
-; Item Cost Overrides are NOT subject to the global price multiplier
 
-; for example, here's an override to make the meme bacon cheaper
+; For example, here's an override to make the meme bacon cheaper
 ;+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=1)))
 ;+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=2)))
+
+; Item Cost Overrides are not subject to the global price multiplier by default
+; Here is an example of how to enable that behaviour using bApplyCostScalars
+;+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(0,1,2), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=35), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=1)), bApplyCostScalars = true)
+;+arrItemCostOverrides=(ItemName="MimicBeacon", Difficulties=(3), NewCost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ArtifactCosts[0]=(ItemTemplateName="CorpseFaceless", Quantity=2)), bApplyCostScalars = true)
 
 ; Vanilla Armors-------------------------
 [MediumPlatedArmor X2ArmorTemplate]

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -112,7 +112,7 @@ static function MakeItemBuildable (name TemplateName, X2ItemTemplateManager Item
 		ItemTemplate.bInfiniteItem = false;
 		ItemTemplate.CreatorTemplateName = '';
 		
-		AdjustItemCost(ItemTemplate);
+		AdjustItemCost(ItemTemplate, GetTemplateDifficulty(ItemTemplate));
 
 		`PA_Trace(ItemTemplate.Name @ "was made single-buildable" @ `showvar(ItemTemplate.Requirements.RequiredTechs.Length));
 	}
@@ -310,61 +310,28 @@ static function OverrideItemCosts ()
 		{
 			ItemTemplate = X2ItemTemplate(DataTemplate);
 
-			if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Rookie))
-			{
-				TemplateDifficulty = 0; // Rookie
-			}
-			else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Veteran))
-			{
-				TemplateDifficulty = 1; // Veteran
-			}
-			else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Commander))
-			{
-				TemplateDifficulty = 2; // Commander
-			}
-			else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Legend))
-			{
-				TemplateDifficulty = 3; // Legend
-			}
-			else
-			{
-				TemplateDifficulty = -1; // Untranslatable Bitfield
-			}
+			TemplateDifficulty = GetTemplateDifficulty(ItemTemplate);
 			
 			if (ItemCostOverrideEntry.Difficulties.Find(TemplateDifficulty) > -1)
 			{
 				`PA_Trace(ItemTemplate.DataName $ " on difficulty " $ TemplateDifficulty $ " has had its cost overridden");
+				
 				ItemTemplate.Cost = ItemCostOverrideEntry.NewCost;
+
+				AdjustItemCost(ItemTemplate, TemplateDifficulty);
 			}
 		}
 	}
 }
 
-static function AdjustItemCost (X2ItemTemplate ItemTemplate)
+static function AdjustItemCost (X2ItemTemplate ItemTemplate, int TemplateDifficulty)
 {
 	local array<StrategyCostScalar> ResourceMultipliers, ArtifactMultipliers;
 	local StrategyCostScalar CostScalar;
-	local int TemplateDifficulty, i;
+	local int i;
 
-	if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Rookie))
+	if (TemplateDifficulty < 0)
 	{
-		TemplateDifficulty = 0; // Rookie
-	}
-	else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Veteran))
-	{
-		TemplateDifficulty = 1; // Veteran
-	}
-	else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Commander))
-	{
-		TemplateDifficulty = 2; // Commander
-	}
-	else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Legend))
-	{
-		TemplateDifficulty = 3; // Legend
-	}
-	else
-	{
-		TemplateDifficulty = -1; // Untranslatable Bitfield
 		`PA_Trace("Cannot adjust cost - invalid difficulty");
 		return;
 	}
@@ -406,6 +373,30 @@ static function AdjustItemCost (X2ItemTemplate ItemTemplate)
 				ItemTemplate.Cost.ArtifactCosts[i].Quantity = Round(ItemTemplate.Cost.ArtifactCosts[i].Quantity * CostScalar.Scalar);
 			}
 		}
+	}
+}
+
+static function int GetTemplateDifficulty (X2ItemTemplate ItemTemplate)
+{
+	if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Rookie))
+	{
+		return 0; // Rookie
+	}
+	else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Veteran))
+	{
+		return 1; // Veteran
+	}
+	else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Commander))
+	{
+		return 2; // Commander
+	}
+	else if (ItemTemplate.IsTemplateAvailableToAllAreas(class'X2DataTemplate'.const.BITFIELD_GAMEAREA_Legend))
+	{
+		return 3; // Legend
+	}
+	else
+	{
+		return -1; // Untranslatable Bitfield
 	}
 }
 

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PATemplateMods.uc
@@ -318,7 +318,7 @@ static function OverrideItemCosts ()
 				
 				ItemTemplate.Cost = ItemCostOverrideEntry.NewCost;
 
-				AdjustItemCost(ItemTemplate, TemplateDifficulty);
+				if (ItemCostOverrideEntry.bApplyCostScalars) AdjustItemCost(ItemTemplate, TemplateDifficulty);
 			}
 		}
 	}

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/PA_DataStructures.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/PA_DataStructures.uc
@@ -26,6 +26,7 @@ struct ItemCostOverride
 	var array<int> Difficulties;
 	var StrategyCost NewCost;
 	var name DLC;
+	var bool bApplyCostScalars;
 };
 
 struct AutoItemConversion


### PR DESCRIPTION
Also reduced code duplication a bunch