### PR TITLE
Implemented configurables to remove upgrades from

### DIFF
--- a/PrototypeArmoury/Config/XComUI.ini
+++ b/PrototypeArmoury/Config/XComUI.ini
@@ -1,3 +1,3 @@
 [PrototypeArmoury.UIUtilities_PA]
 
-+SlotsToStrip=eInvSlot_PrimaryWeapon
++SlotsToStripUpgrades=eInvSlot_PrimaryWeapon

--- a/PrototypeArmoury/Config/XComUI.ini
+++ b/PrototypeArmoury/Config/XComUI.ini
@@ -1,0 +1,3 @@
+[PrototypeArmoury.UIUtilities_PA]
+
++SlotsToStrip=eInvSlot_PrimaryWeapon

--- a/PrototypeArmoury/Localization/PrototypeArmoury.int
+++ b/PrototypeArmoury/Localization/PrototypeArmoury.int
@@ -4,15 +4,15 @@ PageTitle=Prototype Armoury
 
 CanBeChangedInSaveTitle=Can be changed during a campaign
 REMOVE_NICKNAMED_UPGRADES_Label=Remove upgrades from nicknamed items
-REMOVE_NICKNAMED_UPGRADES_Tip="Disabling this will preserve any nicknamed weapon's upgrades when selecting 'MAKE UPGRADES AVAILABLE' at the squad select screen"
+REMOVE_NICKNAMED_UPGRADES_Tip="Disabling this will preserve any nicknamed item's upgrades when selecting 'MAKE UPGRADES AVAILABLE' at the squad select screen"
 
 CanNotBeChangedInSaveTitle=Can NOT be changed during a campaign
 FORCE_LOCK_AND_LOAD_Label=Always enable Lock And Load
-FORCE_LOCK_AND_LOAD_Tip=Allows to always replace weapon upgrades without destroying the previous one. Requires game restart to apply
+FORCE_LOCK_AND_LOAD_Tip=Allows to always replace item upgrades without destroying the previous one. Requires game restart to apply
 
 [UIUtilities_PA]
 strDropUpgrade=REMOVE UPGRADE
 strStripUpgrades=MAKE UPGRADES AVAILABLE
-strStripUpgradesTooltip=Remove all weapon upgrades from primary weapons NOT equipped by soldiers selected for current mission duty.
-strStripUpgradesConfirm=CONFIRM WEAPON UPGRADES AVAILABLE
-strStripUpgradesConfirmDesc=Confirm removal of all weapon upgrades from all primary weapons NOT equipped by soldiers for current mission duty. These weapon upgrades will become available immediately. Upgrades from weapons with nicknames will be <XGParam:StrValue0>. This can be changed in MCM.
+strStripUpgradesTooltip=Remove all upgrades from items NOT equipped by soldiers selected for current mission duty.
+strStripUpgradesConfirm=CONFIRM UPGRADES AVAILABLE
+strStripUpgradesConfirmDesc=Confirm removal of all upgrades from items NOT equipped by soldiers for current mission duty. These upgrades will become available immediately. Upgrades from items with nicknames will be <XGParam:StrValue0>. This can be changed in MCM.

--- a/PrototypeArmoury/PrototypeArmoury.x2proj
+++ b/PrototypeArmoury/PrototypeArmoury.x2proj
@@ -48,6 +48,9 @@
     <Content Include="Config\XComPrototypeArmoury_DEFAULT.ini">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Config\XComUI.ini">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Localization\Items\XComGame.int">
       <SubType>Content</SubType>
     </Content>
@@ -155,7 +158,7 @@
       <SubType>Content</SubType>
     </Content>
   </ItemGroup>
-    <PropertyGroup>
+  <PropertyGroup>
     <SolutionRoot>$(MSBuildProjectDirectory)\..\</SolutionRoot>
     <ScriptsDir>$(SolutionRoot).scripts\</ScriptsDir>
     <BuildCommonRoot>$(ScriptsDir)X2ModBuildCommon\</BuildCommonRoot>

--- a/PrototypeArmoury/Src/PrototypeArmoury/Classes/UIUtilities_PA.uc
+++ b/PrototypeArmoury/Src/PrototypeArmoury/Classes/UIUtilities_PA.uc
@@ -106,6 +106,7 @@ static function OnStripUpgradesDialogCallback (Name eAction)
 	local XComGameState UpdateState;
 	local XComGameState_HeadquartersXCom XComHQ;	
 	local EInventorySlot SlotToStrip;
+	local X2EquipmentTemplate EquipmentTemplate;
 
 	if(eAction == 'eUIAction_Accept')
 	{
@@ -118,9 +119,10 @@ static function OnStripUpgradesDialogCallback (Name eAction)
 
 		foreach Inventory(ItemRef)
 		{
-			ItemState = XComGameState_Item(`XCOMHISTORY.GetGameStateForObjectID(ItemRef.ObjectID));			
-			if (ItemState != none && ItemState.GetMyTemplate().iItemSize > 0 && 				
-				default.SlotsToStrip.Find(ItemState.InventorySlot) != INDEX_NONE &&
+			ItemState = XComGameState_Item(`XCOMHISTORY.GetGameStateForObjectID(ItemRef.ObjectID));
+			EquipmentTemplate = X2EquipmentTemplate(ItemState.GetMyTemplate());
+			if (EquipmentTemplate != none && ItemState.GetMyTemplate().iItemSize > 0 &&
+				default.SlotsToStrip.Find(EquipmentTemplate.InventorySlot) != INDEX_NONE &&
 				ItemState.GetNumUpgradeSlots() > 0 && ItemState.HasBeenModified())
 			{
 				ItemState = XComGameState_Item(UpdateState.ModifyStateObject(class'XComGameState_Item', ItemState.ObjectID));


### PR DESCRIPTION
Closes #26

- New config file `XComUI.ini`
- Removed instances of `eInvSlot_PrimaryWeapon` and read from config instead
- Removed instances of `X2WeaponTemplate` casting and used `ItemState` for all check purpose (to support armor upgrades based on CHL)